### PR TITLE
Allow for css ie6/7 hacks when sorting properties

### DIFF
--- a/class.csstidy_print.php
+++ b/class.csstidy_print.php
@@ -320,12 +320,14 @@ class csstidy_print {
 
 				$invalid = array(
 					'*' => array(), // IE7 hacks first
-					'_' => array()  // IE6 hacks
+					'_' => array(), // IE6 hacks
+					'/' => array(), // IE6 hacks
+					'-' => array()  // IE6 hacks
 				);
 				foreach ($vali as $property => $valj) {
-					$prefix = substr($property, 0, 1);
-					if ($sort_properties && ($prefix === '*' || $prefix === '_')) {
-						$invalid[$prefix][$property] = $valj;
+					$matches = array();
+					if ($sort_properties && preg_match('/^(\*|_|\/|-)(?!(ms|moz|o\b|xv|atsc|wap|khtml|webkit|ah|hp|ro|rim|tc)-)/', $property, $matches)) {
+						$invalid[$matches[1]][$property] = $valj;
 					} else {
 						$this->parser->_add_token(PROPERTY, $property, true);
 						$this->parser->_add_token(VALUE, $valj, true);

--- a/testing/unit-tests/csst/special/ie-hacks-sort.csst
+++ b/testing/unit-tests/csst/special/ie-hacks-sort.csst
@@ -1,0 +1,34 @@
+--TEST--
+IE Hacks Sort Issue/6
+--SETTINGS--
+discard_invalid_properties = 0
+sort_properties = true
+--CSS--
+fakeList a {
+width: 100%;
+display: block;
+height: 30px;
+padding-top: 2px;
+-padding-top: 0;
+line-height:18px;
+-moz-border-radius:10px;
+*line-height:17;
+/line-height:none;
+_background-image: url(/ttt/gf.gif);
+}
+--EXPECT--
+array (
+'fakeList a' =>
+    array (
+      'width' => '100%',
+      'display' => 'block',
+      'height' => '30px',
+      'padding-top' => '2px',
+      '-padding-top' => '0',
+      'line-height' => '18px',
+      '-moz-border-radius' => '10px',
+      '*line-height' => '17',
+      '/line-height' => 'none',
+      '_background-image' => 'url(/ttt/gf.gif)',
+    ),
+)


### PR DESCRIPTION
hacks are moved to the bottom, where ie7 hacks come first then ie6
