### PR TITLE
Improvement to compress_numbers

### DIFF
--- a/class.csstidy_optimise.php
+++ b/class.csstidy_optimise.php
@@ -359,9 +359,14 @@ class csstidy_optimise {
 
 			// Fix bad colors
 			if (in_array($this->property, $color_values)) {
-				$temp[$l] = '#' . $temp[$l];
-				continue;
-			}
+                                if (strlen($temp[$l]) == 3 || strlen($temp[$l]) == 6) {
+                                        $temp[$l] = '#' . $temp[$l];
+                                }
+                                else {
+                                        $temp[$l] = "0";
+                                }
+                                continue;
+                        }
 
 			if (abs($number[0]) > 0) {
 				if ($number[1] == '' && in_array($this->property, $unit_values, true)) {


### PR DESCRIPTION
Only automatically convert numeric color values to hex if they are of length 3 or 6. This avoids values like "#1" which the browser will discard anyway.
