### PR TITLE
Fix for spaces being removed after commas inside of quoted strings.

### DIFF
--- a/class.csstidy.php
+++ b/class.csstidy.php
@@ -552,6 +552,7 @@ class csstidy {
 
 		$all_properties = & $GLOBALS['csstidy']['all_properties'];
 		$at_rules = & $GLOBALS['csstidy']['at_rules'];
+		$quoted_string_properties = & $GLOBALS['csstidy']['quoted_string_properties'];
 
 		$this->css = array();
 		$this->print->input_css = $string;
@@ -711,6 +712,7 @@ class csstidy {
 							$this->str_char = ($string{$i} === '(') ? ')' : $string{$i};
 							$this->status = 'instr';
 							$this->from = 'iv';
+							$this->quoted_string = in_array(strtolower($this->property), $quoted_string_properties);
 						} elseif ($string{$i} === ',') {
 							$this->sub_value = trim($this->sub_value) . ',';
 						} elseif ($string{$i} === '\\') {

--- a/data.inc.php
+++ b/data.inc.php
@@ -418,6 +418,13 @@ $GLOBALS['csstidy']['all_properties']['speak-punctuation'] = 'CSS2.0,CSS2.1';
 $GLOBALS['csstidy']['all_properties']['speak-numeral'] = 'CSS2.0,CSS2.1';
 
 /**
+ * An array containing all properties that can accept a quoted string as a value.
+ *
+ * @global array $GLOBALS['csstidy']['quoted_string_properties']
+ */
+$GLOBALS['csstidy']['quoted_string_properties'] = array('content', 'font-family', 'quotes');
+
+/**
  * An array containing all predefined templates.
  *
  * @global array $GLOBALS['csstidy']['predefined_templates']


### PR DESCRIPTION
e.g.,

foo:after {
content:"A, B, C";
}

was being converted to

foo:after {
content:"A,B,C";
}
