### PR TITLE
Add support for vendor prefix in CSS keyframes

### DIFF
--- a/data.inc.php
+++ b/data.inc.php
@@ -65,7 +65,7 @@ $GLOBALS['csstidy']['units'] = array('in','cm','mm','pt','pc','px','rem','em','%
  * @global array $GLOBALS['csstidy']['at_rules']
  * @version 1.1
  */
-$GLOBALS['csstidy']['at_rules'] = array('page' => 'is','font-face' => 'atis','charset' => 'iv', 'import' => 'iv','namespace' => 'iv','media' => 'at','keyframes' => 'at');
+$GLOBALS['csstidy']['at_rules'] = array('page' => 'is','font-face' => 'atis','charset' => 'iv', 'import' => 'iv','namespace' => 'iv','media' => 'at','keyframes' => 'at','-moz-keyframes' => 'at','-o-keyframes' => 'at','-webkit-keyframes' => 'at','-ms-keyframes' => 'at');
 
  /**
  * Properties that need a value with unit


### PR DESCRIPTION
Hi!

I'm using CSSTidy in one of my projects and I just realized that the keyframes declarations in my CSS file were deleted by the optimization.
I found out that it was because I was using `@-moz-keyframes...` instead of `@keyframes...` which works good with the optimization.

As `@keyframes...` doesn't work in Firefox for now, I modified CSSTidy to accept declarations like `@-moz-keyframes...`.
I also did the same for other prefixes : `-o`, `-webkit` and `-ms`.

It seems to work, and I hope it was the right way to solve the problem.
