### PR TITLE
Fix pour le bug des inherit

### DIFF
--- a/class.csstidy_optimise.php
+++ b/class.csstidy_optimise.php
@@ -899,7 +899,7 @@ class csstidy_optimise {
 		$new_font_value = '';
 		$important = '';
 		// Skip if not font-family and font-size set
-		if (isset($input_css['font-family']) && isset($input_css['font-size'])) {
+		if (isset($input_css['font-family']) && isset($input_css['font-size']) && $input_css['font-family'] != 'inherit') {
 			// fix several words in font-family - add quotes
 			if (isset($input_css['font-family'])) {
 				$families = explode(',', $input_css['font-family']);


### PR DESCRIPTION
On ne peux pas mettre inherit dans un propriété font. donc en skip la compression
dès que l'on trouve un inherit dans font-family.