### PR TITLE
Add space_before_important option

### DIFF
--- a/class.csstidy.php
+++ b/class.csstidy.php
@@ -302,6 +302,7 @@ class csstidy {
 		 */
 		$this->settings['optimise_shorthands'] = 1;
 		$this->settings['remove_last_;'] = true;
+		$this->settings['space_before_important'] = false;
 		/* rewrite all properties with low case, better for later gzip OK, safe*/
 		$this->settings['case_properties'] = 1;
 		/* sort properties in alpabetic order, better for later gzip

--- a/class.csstidy_optimise.php
+++ b/class.csstidy_optimise.php
@@ -269,7 +269,8 @@ class csstidy_optimise {
 	 */
 	public function compress_important(&$string) {
 		if ($this->parser->is_important($string)) {
-			$string = $this->parser->gvw_important($string) . '!important';
+			$important = $this->parser->get_cfg('space_before_important') ? ' !important' : '!important';
+			$string = $this->parser->gvw_important($string) . $important;
 		}
 		return $string;
 	}


### PR DESCRIPTION
This PR adds a new setting called `space_before_important`, which does this:

```css
.selector {
    color: black!important; /* false */
    color: black !important; /* true */
}
```

To set:

```php
$css->set_cfg('space_before_important', true);
```

The default value is `false` so the behavior is exactly the same without specifying the option (prevents breaking change).