### PR TITLE
Add travis, some other changes for composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ testing/simpletest*
 testing/Text*
 nbproject*
 .idea
+vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
+install: composer install
+
+script:
+  - cd testing
+  - php unit-tests.php
+  - cd ..
+
+matrix:
+  allow_failures:
+    - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/pear/Text_Diff"
+            "url": "https://github.com/pear/Text_Diff",
+            "no-api": true
         }
     ],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,29 @@
             "email": "changeme@mailinator.com"
         }
     ],
-    "autoload" : {
-        "classmap": ["."]
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/pear/Text_Diff"
+        }
+    ],
+    "autoload": {
+        "classmap": [
+            "class.csstidy_optimise.php",
+            "class.csstidy_print.php",
+            "class.csstidy.php"
+        ]
+    },
+    "autoload-dev": {
+        "classmap": [
+            "testing"
+        ]
     },
     "require": {
 
+    },
+    "require-dev": {
+        "pear/text_diff": "^1.2",
+        "simpletest/simpletest": "^1.1"
     }
 }

--- a/testing/unit-tests.php
+++ b/testing/unit-tests.php
@@ -33,4 +33,4 @@ foreach ($test_files as $test_file) {
 if (SimpleReporter::inCli()) $reporter = new TextReporter();
 else $reporter = new csstidy_reporter('UTF-8');
 
-$test->run($reporter);
+exit ($test->run($reporter) ? 0 : 1);

--- a/testing/unit-tests.php
+++ b/testing/unit-tests.php
@@ -5,24 +5,15 @@
  * when things go wrong.
  * @author Edward Z. Yang <admin@htmlpurifier.org>
  *
- * Required
- * unit-tets/Text : http://download.pear.php.net/package/Text_Diff-1.1.1.tgz
- * unit-tests/simpletest/ : http://downloads.sourceforge.net/project/simpletest/simpletest/simpletest_1.0.1/simpletest_1.0.1.tar.gz?r=&ts=1289748853&use_mirror=freefr
- *
  */
 
 error_reporting(E_ALL ^ 8192/*E_DEPRECATED*/);
 
 // Configuration
-$simpletest_location = 'simpletest/';
 if (file_exists('../test-settings.php')) include_once '../test-settings.php';
 
 // Includes
-require_once '../class.csstidy.php';
-require_once 'Text/Diff.php';
-require_once 'Text/Diff/Renderer.php';
-require_once $simpletest_location . 'unit_tester.php';
-require_once $simpletest_location . 'reporter.php';
+require_once '../vendor/autoload.php';
 require_once 'unit-tests/class.csstidy_reporter.php';
 require_once 'unit-tests/class.csstidy_harness.php';
 require_once 'unit-tests.inc';
@@ -32,11 +23,11 @@ $test_files = array();
 require 'unit-tests/_files.php';
 
 // Setup test files
-$test = new GroupTest('CSSTidy unit tests');
+$test = new TestSuite('CSSTidy unit tests');
 foreach ($test_files as $test_file) {
 	require_once "unit-tests/$test_file";
 	list($x, $class_suffix) = explode('.', $test_file);
-	$test->addTestClass("csstidy_test_$class_suffix");
+	$test->add("csstidy_test_$class_suffix");
 }
 
 if (SimpleReporter::inCli()) $reporter = new TextReporter();

--- a/testing/unit-tests.php
+++ b/testing/unit-tests.php
@@ -7,7 +7,7 @@
  *
  */
 
-error_reporting(E_ALL ^ 8192/*E_DEPRECATED*/);
+error_reporting(E_ALL);
 
 // Configuration
 if (file_exists('../test-settings.php')) include_once '../test-settings.php';

--- a/testing/unit-tests/class.Text_Diff_Renderer_parallel.php
+++ b/testing/unit-tests/class.Text_Diff_Renderer_parallel.php
@@ -12,7 +12,7 @@ class Text_Diff_Renderer_parallel extends Text_Diff_Renderer
 	var $final    = 'Final';
 	var $_leading_context_lines = 10000; // these are big to ensure entire string is output
 	var $_trailing_context_lines = 10000;
-	function _blockHeader() {}
+	function _blockHeader($xbeg, $xlen, $ybeg, $ylen) {}
 	function _startDiff() {
 		return '<table class="diff"><thead><tr><th>'. $this->original .'</th><th>'. $this->final .'</th></tr></thead><tbody>';
 	}

--- a/testing/unit-tests/class.csstidy_csst.php
+++ b/testing/unit-tests/class.csstidy_csst.php
@@ -107,7 +107,7 @@ class csstidy_csst extends SimpleExpectation
 	/**
 	 * Implements SimpleExpectation::testMessage().
 	 */
-	function testMessage() {
+	function testMessage($compare) {
 		$message = $this->test . ' test at '. htmlspecialchars($this->filename);
 		return $message;
 	}

--- a/testing/unit-tests/class.csstidy_reporter.php
+++ b/testing/unit-tests/class.csstidy_reporter.php
@@ -4,7 +4,7 @@
  * Custom test reporter for CSSTidy, adds appropriate CSS declarations
  * for diffs.
  */
-class csstidy_reporter extends HTMLReporter
+class csstidy_reporter extends HtmlReporter
 {
 
 	function _getCss() {


### PR DESCRIPTION
Thanks for your continued work on this library, and for making it available in composer.

I was recently testing this against PHP 7.2 and ran into the deprecation errors that #49 fixes, but thought it would be nice to have Travis test the changes to be sure that a seemingly simple change doesn't break anything that tests would catch.

This adds Travis support so that any PRs have the tests run against multiple PHP versions.  Currently PHP 7.2 is failing due to the deprecation notice thrown.

I also made some changes to composer.json to autoload a bit better, but I'll explain other changes inline.

If you choose to accept this PR, you'll need to enable this repo in travis-ci.org so that Travis always tests new commits/PRs.

You can view the output of the test run against my fork: https://travis-ci.org/jaydiablo/CSSTidy