### PR TITLE
Fix new PHP7.3 warning

### DIFF
--- a/class.csstidy.php
+++ b/class.csstidy.php
@@ -888,7 +888,7 @@ class csstidy {
 						$this->str_char[] = $string{$i} === '(' ? ')' : $string{$i};
 						$this->from[] = 'instr';
 						$this->quoted_string[] = ($_str_char === ')' && $string{$i} !== '(' && trim($_cur_string)==='(')?$_quoted_string:!($string{$i} === '(');
-						continue;
+						continue 2;
 					}
 
 					if ($_str_char !== ")" && ($string{$i} === "\n" || $string{$i} === "\r") && !($string{$i - 1} === '\\' && !$this->escaped($string, $i - 1))) {


### PR DESCRIPTION
[Since PHP 7.3](http://php.net/manual/en/migration73.incompatible.php#migration73.incompatible.core.continue-targeting-switch) a warning gets thrown when `continue` is used in `switch` blocks. 
Since there was no code after the `switch`, it didn't affect anything (except throw the warning) but it's nicer if it's explicitly stated that a continue of the `for` block should happen.