### PR TITLE
Fix PHP 7.3 compatibility

### DIFF
--- a/class.csstidy.php
+++ b/class.csstidy.php
@@ -888,7 +888,7 @@ class csstidy {
 						$this->str_char[] = $string{$i} === '(' ? ')' : $string{$i};
 						$this->from[] = 'instr';
 						$this->quoted_string[] = ($_str_char === ')' && $string{$i} !== '(' && trim($_cur_string)==='(')?$_quoted_string:!($string{$i} === '(');
-						continue;
+						continue 2;
 					}
 
 					if ($_str_char !== ")" && ($string{$i} === "\n" || $string{$i} === "\r") && !($string{$i - 1} === '\\' && !$this->escaped($string, $i - 1))) {


### PR DESCRIPTION
Fixes `PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?`