### PR TITLE
PHP 8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 8.0
   - nightly
 
 install: composer install

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         ]
     },
     "require": {
-        "php": "^5.4.0 || ^7"
+        "php": "^5.4.0||^7.0||^8.0"
     },
     "require-dev": {
         "pear/text_diff": "^1.2",

--- a/testing/unit-tests.inc
+++ b/testing/unit-tests.inc
@@ -4,32 +4,38 @@
  * Utility functions for unit testing
  */
 
-function globr($sDir, $sPattern, $nFlags = NULL) {
-	$aFiles = glob("$sDir/$sPattern", $nFlags);
-	$files = getDir($sDir);
-	if (is_array($files)) {
-		foreach( $files as $file ) {
-			$aSubFiles = globr($file, $sPattern, $nFlags);
-			$aFiles = array_merge($aFiles,$aSubFiles);
-		}
-	}
-	return $aFiles;
+function globr($sDir, $sPattern, $nFlags = null)
+{
+    $aFiles = glob("$sDir/$sPattern", $nFlags);
+    $files = getDir($sDir);
+    if (is_array($files)) {
+        foreach ($files as $file) {
+            $aSubFiles = globr($file, $sPattern, $nFlags);
+            $aFiles = array_merge($aFiles, $aSubFiles);
+        }
+    }
+
+    return $aFiles;
 }
 
-function getDir($sDir) {
-	$i=0;
-	$aDirs = array();
-	if(is_dir($sDir)) {
-		if($rContents = opendir($sDir)) {
-			while($sNode = readdir($rContents)) {
-				if(is_dir($sDir.'/'.$sNode )) {
-					if($sNode !="." && $sNode !="..") {
-						$aDirs[$i] = $sDir.'/'.$sNode ;
-						$i++;
-					}
-				}
-			}
-		}
-	}
-	return $aDirs;
+if (! function_exists('getDir')) {
+    function getDir($sDir)
+    {
+        $i = 0;
+        $aDirs = array();
+        if (is_dir($sDir)) {
+            if ($rContents = opendir($sDir)) {
+                while ($sNode = readdir($rContents)) {
+                    if (is_dir($sDir . '/' . $sNode)) {
+                        if ($sNode != "." && $sNode != "..") {
+                            $aDirs[$i] = $sDir . '/' . $sNode;
+                            $i++;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $aDirs;
+    }
 }


### PR DESCRIPTION
I'm not 100% how solid this is, but the tests both run and pass on PHP 8.0, both locally and via Travis. My main concern is that simpletest does not currently say it runs on 8.0, however, it seems happy enough to install and run.