### PR TITLE
Check if get_magic_quotes_gpc is available

### DIFF
--- a/css_optimiser.php
+++ b/css_optimiser.php
@@ -31,7 +31,7 @@ require('class.csstidy.php');
 require('lang.inc.php');
 
 
-if (get_magic_quotes_gpc()) {
+if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
 	if (isset($_REQUEST['css_text'])) {
 		$_REQUEST['css_text'] = stripslashes($_REQUEST['css_text']);
 	}


### PR DESCRIPTION
Added a check to see if `get_magic_quotes_gpc()` is available.

This function has been deprecated in PHP 7.4 and removed in PHP 8.0.