### PR TITLE
Fix php8 warnings/errors

### DIFF
--- a/class.csstidy_optimise.php
+++ b/class.csstidy_optimise.php
@@ -134,6 +134,13 @@ class csstidy_optimise {
 				}
 			}
 		}
+
+		// Custom fix for badly formatted comments that look like this: /*!* RESET STYLES *!*/
+		foreach ($this->css as $medium => $value) {
+			if (is_string($value)) {
+				unset($this->css[$medium]);
+			}
+		}
 	}
 
 	/**

--- a/class.csstidy_optimise.php
+++ b/class.csstidy_optimise.php
@@ -341,7 +341,7 @@ class csstidy_optimise {
 			for ($i = 0; $i < count($color_tmp); $i++) {
 				$color_tmp[$i] = trim($color_tmp[$i]);
 				if (substr($color_tmp[$i], -1) === '%') {
-					$color_tmp[$i] = round((255 * $color_tmp[$i]) / 100);
+					$color_tmp[$i] = round((255 * (int) $color_tmp[$i]) / 100);
 				}
 				if ($color_tmp[$i] > 255)
 					$color_tmp[$i] = 255;

--- a/class.csstidy_print.php
+++ b/class.csstidy_print.php
@@ -350,7 +350,9 @@ class csstidy_print {
 
 		// important comment section ?
 		if (isset($this->css['!'])) {
-			$this->parser->_add_token(IMPORTANT_COMMENT, rtrim($this->css['!']), true);
+			if (is_string($this->css['!'])) {
+				$this->parser->_add_token(IMPORTANT_COMMENT, rtrim($this->css['!']), true);
+			}
 			unset($this->css['!']);
 		}
 


### PR DESCRIPTION
Fixing random issues found in parsing emails that result in errors when attempting to purify using htmlpurifier

Badly formatted comment block in `<style>`
```
/*!* CLIENT-SPECIFIC STYLES *!*/
```

Results in `rtrim() expects parameter 1 to be string, array given`

Due to the remaining string after parsing the css a related warning is generated in htmlpurifier uses this library

Invalid RGB values
```
rgb(1,2,a%)
```

Results in `Uncaught exception 'TypeError' with message 'Unsupported operand types: string * int'`