### PR TITLE
fix: composer works fine wihout vcs repo for pear/Text_Diff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,6 @@
             "email": "changeme@mailinator.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/pear/Text_Diff",
-            "no-api": true
-        }
-    ],
     "autoload": {
         "classmap": [
             "class.csstidy_optimise.php",


### PR DESCRIPTION
As `pear/text_diff` is present on [packagist](https://packagist.org/packages/pear/text_diff), there is no need to specify a vcs repository