### PR TITLE
fix error -> Undefined offset: 0 - PHP 8.2

### DIFF
--- a/class.csstidy_print.php
+++ b/class.csstidy_print.php
@@ -285,7 +285,9 @@ class csstidy_print {
 					else {
 						$out = & $output;
 					}
-					$out .= $template[10] . $in_at_out[$indent_level];
+          if (isset($in_at_out[$indent_level])) {
+            $out .= $template[10] . $in_at_out[$indent_level];
+          }
 					if ($this->_seeknocomment($key, 1) != AT_END) {
 						$out .= $template[9];
 					}


### PR DESCRIPTION
Applied a condition check to fix the Actual Error that is causing in my site's reports. 

```bash
PHP Notice:  Undefined offset: 0 in "/vendor/cerdic/css-tidy/class.csstidy_print.php on line 288" while reading response header from upstream, client: 127.0.0.1, server
```

