### PR TITLE
fix: ignore .github and Docs directories at export (zip)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,5 @@
 /phpunit.xml.dist export-ignore
 /phpunit.7.5.xml export-ignore
 /tests/ export-ignore
+/.github/ export-ignore
+/Docs/ export-ignore


### PR DESCRIPTION
To avoid the files below to be downloaded and installed when using composer

```txt
vendor/cerdic/css-tidy/.github/workflows/build.yml
vendor/cerdic/css-tidy/Docs/__filesource/fsource_csstidy__class.csstidy.php.html
vendor/cerdic/css-tidy/Docs/__filesource/fsource_csstidy__class.csstidy_optimise.php.html
vendor/cerdic/css-tidy/Docs/__filesource/fsource_csstidy__class.csstidy_print.php.html
vendor/cerdic/css-tidy/Docs/__filesource/fsource_csstidy__data.inc.php.html
vendor/cerdic/css-tidy/Docs/classtrees_csstidy.html
vendor/cerdic/css-tidy/Docs/csstidy/_class_csstidy_optimise_php.html
vendor/cerdic/css-tidy/Docs/csstidy/_class_csstidy_php.html
vendor/cerdic/css-tidy/Docs/csstidy/_class_csstidy_print_php.html
vendor/cerdic/css-tidy/Docs/csstidy/_data_inc_php.html
vendor/cerdic/css-tidy/Docs/csstidy/csstidy.html
vendor/cerdic/css-tidy/Docs/csstidy/csstidy_optimise.html
vendor/cerdic/css-tidy/Docs/csstidy/csstidy_print.html
vendor/cerdic/css-tidy/Docs/elementindex.html
vendor/cerdic/css-tidy/Docs/elementindex_csstidy.html
vendor/cerdic/css-tidy/Docs/errors.html
vendor/cerdic/css-tidy/Docs/index.html
vendor/cerdic/css-tidy/Docs/li_csstidy.html
vendor/cerdic/css-tidy/Docs/media/background.png
vendor/cerdic/css-tidy/Docs/media/empty.png
vendor/cerdic/css-tidy/Docs/media/style.css
vendor/cerdic/css-tidy/Docs/todolist.html
 ```
